### PR TITLE
Syntax Highlighting Overhaul

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "syntaxes"]
+	path = syntaxes
+	url = git@github.com:Shopify/liquid-tm-grammar.git

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,5 +29,6 @@
 3.  Install node deps + build extension + publish (assumes you have `vsce` globally installed - `yarn global add vsce`)
 
     ```bash
-    yarn && yarn build && vsce publish $VERSION
+    vsce login Shopify
+    yyarn && yarn build &&arn && yarn build && vsce publish $VERSION
     ```

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
     "url": "https://github.com/shopify/theme-check-vscode.git"
   },
   "scripts": {
-    "prebuild": "yarn && rimraf dist language-configuration.json",
     "build": "yarn build:extension && yarn build:language-config",
     "build:extension": "webpack --mode production",
     "build:language-config": "scripts/make-language-configuration",
     "dev": "rimraf dist && webpack --mode development --watch",
+    "dev:syntax": "yarn --cwd ./syntaxes dev",
     "package": "yarn build && vsce package",
+    "postinstall": "yarn --cwd ./syntaxes install",
+    "prebuild": "yarn && rimraf dist language-configuration.json",
     "test": "mocha 'src/**/*.test.js'"
   },
   "engines": {
@@ -80,22 +82,30 @@
           "description": "Path to theme-check-language-server. Defaults to `which theme-check-language-server` if available on `$PATH`."
         },
         "shopifyLiquid.disableWindowsWarning": {
-          "type": ["boolean"],
+          "type": [
+            "boolean"
+          ],
           "description": "When true, theme check won't bug you with the Windows warning anymore.",
           "default": false
         },
         "themeCheck.checkOnOpen": {
-          "type": ["boolean"],
+          "type": [
+            "boolean"
+          ],
           "description": "When true, theme check runs on file open.",
           "default": true
         },
         "themeCheck.checkOnChange": {
-          "type": ["boolean"],
+          "type": [
+            "boolean"
+          ],
           "description": "When true, theme check runs on file change.",
           "default": true
         },
         "themeCheck.checkOnSave": {
-          "type": ["boolean"],
+          "type": [
+            "boolean"
+          ],
           "description": "When true, theme check runs on file open.",
           "default": true
         }
@@ -119,7 +129,18 @@
       {
         "language": "liquid",
         "scopeName": "text.html.liquid",
-        "path": "./liquid.tmLanguage"
+        "path": "./syntaxes/liquid.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.css": "css",
+          "meta.embedded.block.js": "javascript"
+        }
+      },
+      {
+        "path": "./syntaxes/liquid-injection.tmLanguage.json",
+        "scopeName": "liquid.injection",
+        "injectTo": [
+          "text.html.liquid"
+        ]
       }
     ]
   },
@@ -129,6 +150,7 @@
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",
     "mocha": "^8.3.2",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "vscode-test": "^1.3.0",
     "webpack": "^5.28.0",


### PR DESCRIPTION
This PR is an overhaul of the syntax highlighting for liquid.

Repo changes:

- It moves the syntax to [Shopify/liquid-tm-grammar](/Shopify/liquid-tm-grammar).
- The syntax is included as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
- [Shopify/liquid-tm-grammar](/Shopify/liquid-tm-grammar) boasts a couple of development workflow improvements
  - It has unit tests, refactors are no longer scary
  - The syntax is in YAML instead of the ugly ugly UGLY XML .plist files
  - It has a sane(-ish) workflow where you can cmd+R in VS Code and see the result of your changes

Major new features from the improved grammar:

- Liquid in JS syntax highlighting
- Liquid in CSS syntax highlighting
- JSON syntax highlighting in {% schema %} tags
- JS + Liquid syntax highlighting in {% javascript %} tags
- CSS + Liquid syntax highlighting in {% style %} tags
- Raw tag proper syntax highlighting
- … and more

## Screenshots

Here is a before and after showcase:
