### PR TITLE
Update link in README to CLI install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This VS Code extensions depends on the [Theme Check][tc] language server, which 
 
 To install the `shopify` CLI, follow these steps:
 
-1. Go to https://shopify.dev/tools/cli/installation
+1. Go to https://shopify.dev/themes/tools/cli/install
 2. Follow the instructions for your operating system
 
 -----

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Official VS Code extension for [Shopify Liquid](https://shopify.dev/docs/themes)
 
 ## Installation
 
-This VS Code extensions depends on the [Theme Check][tc] language server, which is bundled in the latest [Shopify CLI](https://shopify.dev/tools/cli).
+This VS Code extensions depends on the [Theme Check][tc] language server, which is bundled in the latest [Shopify CLI](https://shopify.dev/themes/tools/cli).
 
 To install the `shopify` CLI, follow these steps:
 


### PR DESCRIPTION
### Problem

When extension users go through Installation steps (either via [Marketplace](https://marketplace.visualstudio.com/items?itemName=Shopify.theme-check-vscode) or via page in VS Code), they will click on https://shopify.dev/tools/cli/installation

This link however redirects to the CLI’s _Apps_ section.

### Solution

Update the aforementioned link to https://shopify.dev/themes/tools/cli/install, so that users install the app globally (for theme development), and also see the system requirements.