### PR TITLE
Add posix sh command existence compliance

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -256,7 +256,7 @@ async function themeCheckExecutable(
 
 async function commandExists(command: string): Promise<void> {
   try {
-    !isWin && (await exec(`[[ -f "${command}" ]]`));
+    !isWin && (await exec(`[ -f "${command}" ]`));
   } catch (e) {
     throw new CommandNotFoundError(
       `${command} not found, are you sure this is the correct path?`,


### PR DESCRIPTION
I'm receiving the following error:

> [theme-check-language-server] not found, are you sure this is the correct path

The path indeed exists, and executes fine. The problem is the following (condensed) code:

```js
const { promisify } = require("util");
const child_process = require("child_process");
const exec = promisify(child_process.exec);
exec(`[[ -f "/usr/local/rvm/gems/default/bin/theme-check-language-server" ]]`)
```

Will return the following error

```
Error: Command failed: [[ -f "/usr/local/rvm/gems/default/bin/theme-check-language-server" ]]
/bin/sh: 1: [[: not found

    at __node_internal_genericNodeError (node:internal/errors:868:15)
    at ChildProcess.exithandler (node:child_process:419:12)
    at ChildProcess.emit (node:events:513:28)
    at ChildProcess.emit (node:domain:552:15)
    at maybeClose (node:internal/child_process:1091:16)
    at Socket.<anonymous> (node:internal/child_process:449:11)
    at Socket.emit (node:events:513:28)
    at Socket.emit (node:domain:552:15) {
  code: 127,
  killed: false,
  signal: null,
  cmd: '[[ -f "/usr/local/rvm/gems/default/bin/theme-check-language-server" ]]',
  stdout: '',
  stderr: '/bin/sh: 1: [[: not found\n'
}
```

And this is interpreted as the file not existing. The root cause is [due to `[[` being undefined in POSIX sh](https://www.shellcheck.net/wiki/SC3010). If the shell was bash, this would be fine.

However, the following works and is more portable:

```js
exec(`[ -f "/usr/local/rvm/gems/default/bin/theme-check-language-server" ]`)
```