### PR TITLE
feat: @cris Support use prettier config file in root project

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@shopify/prettier-plugin-liquid": "^1.1.0",
-    "prettier": "^2.6.2",
+    "prettier": "^2.8.7",
     "vsce": "^1.87.0",
     "vscode-languageclient": "^8.0.0"
   },
@@ -148,6 +148,12 @@
           ],
           "description": "When true, disables whole theme checks. Can improve performance. (theme-check v1.10.0+)",
           "default": false
+        },
+        "shopifyLiquid.useProjectPrettierConfig": {
+          "type": [
+            "boolean"
+          ],
+          "description": "When true, use prettier config file in project root dir."
         }
       }
     },

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -80,6 +80,7 @@ async function toTextEdit(textDocument: TextDocument): Promise<TextEdit> {
       }
       return item;
     });
+    prettierOptions.parser = 'liquid-html';
   } else {
     prettierOptions = {
       ...options,

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -6,6 +6,7 @@ import {
   Diagnostic,
   Range,
   Position,
+  workspace,
 } from 'vscode';
 import * as prettier from 'prettier';
 import * as LiquidPrettierPlugin from '@shopify/prettier-plugin-liquid/standalone';
@@ -54,13 +55,47 @@ export default class LiquidFormatter {
 }
 
 async function toTextEdit(textDocument: TextDocument): Promise<TextEdit> {
+  const useProjectPrettierConfig = workspace
+    .getConfiguration('shopifyLiquid')
+    .get('useProjectPrettierConfig');
+
   const options = await prettier.resolveConfig(textDocument.uri.fsPath);
   const text = textDocument.getText();
-  const formatted = prettier.format(text, {
-    ...options,
-    parser: 'liquid-html',
-    plugins: [LiquidPrettierPlugin],
-  });
+
+  let prettierOptions: prettier.Options = {};
+  if (useProjectPrettierConfig) {
+    prettierOptions = options || {};
+
+    // if use prettier auto plugin
+    prettierOptions.plugins = prettierOptions.plugins?.map((item) => {
+      if (typeof item === 'string') {
+        const workspaceFolder = workspace.getWorkspaceFolder(textDocument.uri);
+        if (workspaceFolder) {
+          const moduleAbsoluteUri = Uri.joinPath(
+            workspaceFolder?.uri,
+            `node_modules/${item}`,
+          );
+          return moduleAbsoluteUri.path;
+        }
+      }
+      return item;
+    });
+  } else {
+    prettierOptions = {
+      ...options,
+      parser: 'liquid-html',
+      plugins: [LiquidPrettierPlugin],
+    };
+  }
+
+  let formatted = text;
+
+  try {
+    formatted = prettier.format(text, prettierOptions);
+  } catch (e) {
+    console.error('formatter error', e);
+  }
+
   const start = textDocument.positionAt(0);
   const end = textDocument.positionAt(text.length);
   return TextEdit.replace(new Range(start, end), formatted);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,10 +1991,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@^2.8.7:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Old version only support prettier config except plugins. If user use plugin like tailwindcss, it would not format tailwindcss class in liquid file. So I did this to use project prettier config fully if user set useProjectPrettierConfig to true.